### PR TITLE
run all fuzzers in docker

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -3,30 +3,47 @@ import random
 import re
 from logging import error
 from common import *
+from typing import Tuple
 
 
-def oss_fuzz_one_target(p, proj, fuzztime):
-    target, fuzzout = p
-    return subprocess.Popen(
-        [
-            "python3",
-            f"{OSSFUZZ}/infra/helper.py",
-            "run_fuzzer",
-            proj,
-            target,
-            f"\-max_total_time={fuzztime}",
-            "\-rss_limit_mb=0",
-            "--engine",
-            "libfuzzer",
-            "--corpus-dir",
-            fuzzout,
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+def oss_fuzz_one_target(
+    p: Tuple[str, str, str | None], proj: str, fuzztime: int
+) -> subprocess.Popen:
+    target, fuzzout, dump = p
+    cmd = [
+        "python3",
+        f"{OSSFUZZ}/infra/helper.py",
+        "run_fuzzer",
+        proj,
+        target,
+        f"\-max_total_time={fuzztime}",
+        "\-rss_limit_mb=0",
+        "--engine",
+        "libfuzzer",
+        "--corpus-dir",
+        fuzzout,
+    ]
+
+    if dump is None:
+        job = subprocess.Popen(
+            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+    else:
+        # todo: change mode to "a" if a fuzzer has multiple dump
+        with open(dump, "w") as dumpfile:
+            job = subprocess.Popen(
+                cmd,
+                stdout=dumpfile,
+                stderr=subprocess.DEVNULL,
+            )
+    return job
 
 
 def run_one_fuzzer(p, runtime):
+    """Deprecated, the function is left as a placeholder for future to
+    find a way for libFuzzer to run without refuzzing
+    """
+    warning("run_one_fuzzer is deprecated, please use oss_fuzz_one_target instead")
     target, corpus_dir, dump = p
     cmd = [
         target,


### PR DESCRIPTION
some projects (like `coturn`) uses dynamic library somewhere in docker, so the old `run_one_fuzzer` would not work. This solve the issue.